### PR TITLE
Feature/mutable state in data store

### DIFF
--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/TypeExtensions.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/TypeExtensions.cs
@@ -24,10 +24,13 @@ namespace com.csutil {
 
         // From https://stackoverflow.com/a/863944/165106
         public static bool IsPrimitiveOrSimple(this Type t) {
-            var i = t.GetTypeInfo();
+            if (t.IsPrimitive || t.IsEnum || t.Equals(typeof(string)) || t.Equals(typeof(decimal))) { return true; }
+            var info = t.GetTypeInfo();
             // nullable type, check if the nested type is simple:
-            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(Nullable<>)) { return IsPrimitiveOrSimple(i.GetGenericArguments()[0]); }
-            return i.IsPrimitive || i.IsEnum || t.Equals(typeof(string)) || t.Equals(typeof(decimal));
+            if (info.IsGenericType && info.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                return IsPrimitiveOrSimple(info.GetGenericArguments()[0]);
+            }
+            return false;
         }
 
         public static bool IsSystemType(this Type type) { return type.Assembly == typeof(object).Assembly; }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/immutable/ReplayRecorder.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/immutable/ReplayRecorder.cs
@@ -90,7 +90,7 @@ namespace com.csutil.model.immutable {
             var nextEntry = jsonReader.Read<Entry>(nextEntryJson);
             try {
                 targetStore.Dispatch(nextEntry.action);
-            } catch (System.Exception e) {
+            } catch (Exception e) {
                 CompareErrors(nextEntry, e);
             }
         }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/immutable/StateCompare.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/immutable/StateCompare.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace com.csutil.model.immutable {
+
+    public class StateCompare {
+
+        private static StateCompare instance = new StateCompare();
+
+        /// <summary> The nr that represents the time of the last dispatch </summary>
+        private long lastDispatchStart;
+        /// <summary> The nr that represents the time of the last dispatch </summary>
+        private long lastDispatchEnd;
+
+        /// <summary> This has to be called by a store middleware  for every new dispatch if a 
+        /// store should support mutable data. </summary>
+        public static void SetStoreDispatchingStarted() {
+            instance.lastDispatchStart = Stopwatch.GetTimestamp();
+        }
+
+        public static void SetStoreDispatchingEnded() {
+            instance.lastDispatchEnd = Stopwatch.GetTimestamp();
+        }
+
+        public static bool IsCurrentlyDispatching() {
+            return instance.lastDispatchStart > instance.lastDispatchEnd;
+        }
+
+        public static bool WasModified<S>(S oldState, S newState) {
+            if (typeof(S).IsPrimitiveOrSimple() && !Equals(oldState, newState)) { return true; }
+            if (!ReferenceEquals(oldState, newState)) { return true; }
+            if (oldState is IsMutable m) { return WasModifiedInLastDispatch(m); }
+            return false;
+        }
+
+        public static bool WasModifiedInLastDispatch(IsMutable mutableData) {
+            return instance.lastDispatchStart < mutableData.LastMutation;
+        }
+
+    }
+
+    /// <summary> Has to be implemented by any mutable data model that is stored in a data store </summary>
+    public interface IsMutable {
+        /// <summary> A tick value (not a timestamp!) when the instance was last mutated, should 
+        /// only be modified by calling object.MarkMutated() </summary>
+        long LastMutation { get; set; }
+    }
+
+    public static class IsMutableExtensions {
+
+        /// <summary> This should only be used in the datastore dispatchers, marks that 
+        /// the object was modified by the dispatched mutation </summary>
+        public static void MarkMutated(this IsMutable self) {
+            if (!StateCompare.IsCurrentlyDispatching()) {
+                throw new InvalidOperationException("Model was modified outside of the dispatchers");
+            }
+            self.LastMutation = Stopwatch.GetTimestamp();
+        }
+
+        /// <summary> Will be true if the object was modified when the last mutation was 
+        /// dispatched via the data store the object is managed in </summary>
+        public static bool WasModifiedInLastDispatch(this IsMutable self) {
+            return StateCompare.WasModifiedInLastDispatch(self);
+        }
+
+    }
+
+}

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/immutable/DataStoreExample3.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/immutable/DataStoreExample3.cs
@@ -24,7 +24,7 @@ namespace com.csutil.tests.model.immutable {
             // Add a thunk middleware to allow dispatching async actions:
             var thunkMiddleware = Middlewares.NewThunkMiddleware<MyAppState1>();
 
-            // aDD A logging middleware to log all dispatched actions:
+            // Add A logging middleware to log all dispatched actions:
             var loggingMiddleware = Middlewares.NewLoggingMiddleware<MyAppState1>();
 
             var serverOutboxHandler = new ServerOutboxHandler<MyAppState1>();

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/immutable/DataStoreExample4.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/immutable/DataStoreExample4.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.csutil.model.immutable;
+using Xunit;
+
+namespace com.csutil.tests.model.immutable {
+
+    /// <summary> This example uses a mutable datamodel, which means that the 
+    /// data store cant guarantee that the model wasn't modified outside of the reducers but allows to
+    /// use the data store for models that partly have to be mutable (e.g. because they
+    /// are not fully controlled by the developer). 
+    /// 
+    /// The main challange with mutable data is to propagate changes upwards through the model and mark
+    /// all parent objects as changed as well. This example shows how this can be done following the 
+    /// typical Reducer patterns also used very similarly with immutable data models. 
+    /// </summary>
+    public class DataStoreExample4 {
+
+        public DataStoreExample4(Xunit.Abstractions.ITestOutputHelper logger) { logger.UseAsLoggingOutput(); }
+
+        [Fact]
+        public void ExampleUsage1() {
+            var t = Log.MethodEntered("DataStoreExample3.ExampleUsage1");
+
+            // A middleware that will allow to use mutable data in the data store:
+            var thunkMiddleware = Middlewares.NewMutableDataSupport<MyAppState1>();
+
+            // Add A logging middleware to log all dispatched actions:
+            var loggingMiddleware = Middlewares.NewLoggingMiddleware<MyAppState1>();
+
+            MyUser1 user = new MyUser1() { name = "Carl" };
+            var model = new MyAppState1() { user = user };
+
+            var store = new DataStore<MyAppState1>(MyReducers1.ReduceMyAppState1, model, loggingMiddleware, thunkMiddleware);
+            IoC.inject.SetSingleton(store);
+            store.storeName = "Store 4";
+
+            // Setup 3 listeners that react when the name of the user or his contacts change:
+            var userChangedCounter = 0;
+            var userNameChangedCounter = 0;
+            var contact1NameChangedCounter = 0;
+            var contact2NameChangedCounter = 0;
+            store.AddStateChangeListener(s => s.user, (MyUser1 theChangedUser) => {
+                userChangedCounter++;
+            });
+            store.AddStateChangeListener(s => s.user?.name, (string theChangedName) => {
+                userNameChangedCounter++;
+            });
+            store.AddStateChangeListener(s => s.user?.contacts?.FirstOrDefault()?.contactData.name, (_) => {
+                contact1NameChangedCounter++;
+            });
+            store.AddStateChangeListener(s => s.user?.contacts?.Skip(1).FirstOrDefault()?.contactData.name, (_) => {
+                contact2NameChangedCounter++;
+            });
+
+            var contact1 = new MyUser1() { name = "Tom" };
+            { // Add a first contact to the user:
+                Assert.Null(user.contacts);
+                store.Dispatch(new ActionAddContact() {
+                    targetUserId = user.id,
+                    newContact = new MyContact1() { contactData = contact1 }
+                });
+                Assert.Same(contact1, user.contacts.First().contactData);
+                Assert.True(user.WasModifiedInLastDispatch());
+
+                // Now that there is a contact 1 the listener was triggered: 
+                Assert.Equal(1, userChangedCounter);
+                Assert.Equal(0, userNameChangedCounter);
+                Assert.Equal(1, contact1NameChangedCounter);
+                Assert.Equal(0, contact2NameChangedCounter);
+            }
+
+            var contact2 = new MyUser1() { name = "Bill" };
+            { // Add a second contact to the user which should not affect contact 1:
+                store.Dispatch(new ActionAddContact() {
+                    targetUserId = user.id,
+                    newContact = new MyContact1() { contactData = contact2 }
+                });
+                Assert.Same(contact2, user.contacts.Last().contactData);
+                Assert.True(user.WasModifiedInLastDispatch());
+                Assert.False(contact1.WasModifiedInLastDispatch());
+
+                Assert.Equal(2, userChangedCounter);
+                Assert.Equal(0, userNameChangedCounter);
+                Assert.Equal(1, contact1NameChangedCounter);
+                Assert.Equal(1, contact2NameChangedCounter);
+            }
+            { // Change the name of contact 1 which should not affect contact 2:
+                var newName1 = "Toooom";
+                store.Dispatch(new ActionChangeUserName() { targetUserId = contact1.id, newName = newName1 });
+                Assert.True(user.WasModifiedInLastDispatch());
+                Assert.True(contact1.WasModifiedInLastDispatch());
+                Assert.False(contact2.WasModifiedInLastDispatch());
+
+                Assert.Equal(3, userChangedCounter);
+                Assert.Equal(0, userNameChangedCounter);
+                Assert.Equal(2, contact1NameChangedCounter);
+                Assert.Equal(1, contact2NameChangedCounter);
+            }
+            { // Change the name of the user which should not affect the 2 contacts:
+                var newName = "Caaaarl";
+                Assert.NotEqual(newName, user.name);
+                Assert.Equal(user.name, store.GetState().user.name);
+                var tBeforeDispatch = user.LastMutation;
+                store.Dispatch(new ActionChangeUserName() { targetUserId = user.id, newName = newName });
+                Assert.Equal(newName, store.GetState().user.name);
+                Assert.Equal(newName, user.name);
+                Assert.Same(model, store.GetState());
+
+                Assert.NotEqual(tBeforeDispatch, user.LastMutation);
+                Assert.True(user.WasModifiedInLastDispatch());
+                Assert.False(contact1.WasModifiedInLastDispatch());
+                Assert.False(contact2.WasModifiedInLastDispatch());
+
+                Assert.Equal(4, userChangedCounter);
+                Assert.Equal(1, userNameChangedCounter);
+                Assert.Equal(2, contact1NameChangedCounter);
+                Assert.Equal(1, contact2NameChangedCounter);
+            }
+            { // Marking an object mutated while not dispatching will throw an exception:
+                Assert.Throws<InvalidOperationException>(() => {
+                    user.name = "Cooorl";
+                    user.MarkMutated();
+                });
+                Assert.Equal(4, userChangedCounter); // Count should not have changed
+                Assert.Equal(1, userNameChangedCounter); 
+            }
+        }
+
+        #region example Model (which is mutable)
+
+        private class MyAppState1 : IsMutable {
+            public MyUser1 user;
+            public long LastMutation { get; set; }
+        }
+
+        private class MyUser1 : IsMutable {
+            public Guid id { get; } = Guid.NewGuid();
+            public string name;
+            public List<MyContact1> contacts;
+            public long LastMutation { get; set; }
+        }
+
+        private class MyContact1 : IsMutable {
+            public MyUser1 contactData;
+            public DateTime becameFriendsDate = DateTimeV2.Now;
+            public long LastMutation { get; set; }
+        }
+
+        #endregion
+
+        #region example actions
+
+        private class ActionChangeUserName {
+            public Guid targetUserId;
+            public string newName;
+        }
+
+        private class ActionAddContact {
+            public Guid targetUserId;
+            public MyContact1 newContact;
+        }
+
+        #endregion // of example actions
+
+        private static class MyReducers1 { // The reducers to modify the immutable datamodel:
+
+            // The most outer reducer is public to be passed into the store:
+            public static MyAppState1 ReduceMyAppState1(MyAppState1 model, object action) {
+                bool changed = false;
+                model.MutateField(model.user, action, (_, user, a) => ReduceUser(user, a), ref changed);
+                if (changed) { model.MarkMutated(); }
+                return model;
+            }
+
+            private static MyUser1 ReduceUser(MyUser1 user, object action) {
+                var changed = false;
+                if (action is ActionChangeUserName a) {
+                    if (a.targetUserId == user.id) {
+                        user.name = a.newName;
+                        user.MarkMutated();
+                        changed = true;
+                    }
+                }
+                user.contacts = user.MutateField(user.contacts, action, ContactsReducer, ref changed);
+                if (changed) { user.MarkMutated(); }
+                return user;
+            }
+
+            private static List<MyContact1> ContactsReducer(MyUser1 parent, List<MyContact1> contacts, object action) {
+                var changed = false;
+                contacts.MutateEntries(action, ContactReducer, ref changed);
+                if (action is ActionAddContact c) {
+                    if (c.targetUserId == parent.id) {
+                        if (contacts == null) { contacts = new List<MyContact1>(); }
+                        contacts.Add(c.newContact);
+                        changed = true;
+                    }
+                }
+                if (changed) { parent.MarkMutated(); }
+                return contacts;
+            }
+
+            private static MyContact1 ContactReducer(MyContact1 contact, object action) {
+                var changed = false;
+                contact.MutateField(contact.contactData, action, (_, user, a) => ReduceUser(user, a), ref changed);
+                if (changed) { contact.MarkMutated(); }
+                return contact;
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Added some additional extensions and a new Redux data store example to allow using mutable data in a data store but still keeping the advantages of enforcing mutations via reducers. 

The main challenge with mutable data is to propagate changes upwards through the model and mark all parent objects as changed as well. This example shows how this can be done following the typical Reducer patterns also used very similarly with immutable data models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cs-util-com/cscore/60)
<!-- Reviewable:end -->
