### PR TITLE
Fix HasDiscPrefix

### DIFF
--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/io/ZioExtensions.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/io/ZioExtensions.cs
@@ -47,11 +47,11 @@ namespace com.csutil {
         private static string ExtractDiscPrefix(DirectoryInfo dir) { return ExtractDiscPrefix(dir.FullName); }
 
         private static string ExtractDiscPrefix(string absPath) {
-            if (HasDiscPrefix(absPath)) { throw new InvalidDataException("Path does not contain a disc prefix: " + absPath); }
+            if (!HasDiscPrefix(absPath)) { throw new InvalidDataException("Path does not contain a disc prefix: " + absPath); }
             return absPath.Substring(0, 2);
         }
 
-        private static bool HasDiscPrefix(string absPath) { return absPath[1] != ':'; }
+        private static bool HasDiscPrefix(string absPath) { return absPath[1] == ':'; }
 
         public static DirectoryEntry AsNewRootDir(this DirectoryEntry self) {
             return new SubFileSystem(self.FileSystem, self.Path).GetDirectoryEntry(UPath.Root);


### PR DESCRIPTION
This function used the inverse check (HasNoDiscPrefix) and was then used incorrectly. This changes the check to match the name and fixes the usage in ExtractDiscPrefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cs-util-com/cscore/64)
<!-- Reviewable:end -->
