### PR TITLE
Improve NewDateTimeFromUnixTimestamp

### DIFF
--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/DateTimeV2.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/DateTimeV2.cs
@@ -13,13 +13,11 @@ namespace com.csutil {
 
         public static DateTime NewDateTimeFromUnixTimestamp(long unixTimeInMs, bool autoCorrectIfPassedInSeconds = true) {
             AssertV2.IsTrue(unixTimeInMs > 0, "NewDateTimeFromUnixTimestamp: unixTimeInMs was " + unixTimeInMs);
-            System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            var result = dtDateTime.AddMilliseconds(unixTimeInMs);
+            DateTime result = DateTimeOffset.FromUnixTimeMilliseconds(unixTimeInMs).UtcDateTime;
             if (autoCorrectIfPassedInSeconds && result.Year == 1970) {
-                var correctedDate = NewDateTimeFromUnixTimestamp(unixTimeInMs * 1000, false);
-                Log.e("The passed unixTimeInMs was likely passed in seconds instead of milliseconds,"
-                    + " it was too small by a factor of *1000, which would result in " + correctedDate.ToReadableString());
-                return correctedDate;
+                Log.w("The passed unixTimeInMs was likely passed in seconds instead of milliseconds,"
+                    + " it was too small by a factor of *1000, which would result in " + result.ToReadableString());
+                return DateTimeOffset.FromUnixTimeSeconds(unixTimeInMs).UtcDateTime;
             }
             return result;
         }


### PR DESCRIPTION
This addresses multiple points:
* Uses the new API from DateTimeOffset to get a UtcDateTime
* Log a warning instead of error when the timestamp was (probably) in seconds
* Fixes the logged message to use the (probably) wrong date instead of the fixed one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cs-util-com/cscore/65)
<!-- Reviewable:end -->
