### PR TITLE
Feature/urp blur

### DIFF
--- a/CsCore/.github/workflows/dotnet-tests.yml
+++ b/CsCore/.github/workflows/dotnet-tests.yml
@@ -1,0 +1,66 @@
+name: .NET Tests (Safe Caching + Reporting + Exclude IntegrationTests)
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read  # always minimal
+  checks: write   # needed to post check run
+  pull-requests: none
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: none
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            Directory.Packages.props
+
+      - name: Restore dependencies
+        run: dotnet restore CsCore/CsCore.sln
+
+      - name: Build solution
+        run: dotnet build CsCore/CsCore.sln --no-restore
+
+      - name: Run xUnit tests (exclude integrationTests)
+        run: >
+          dotnet test CsCore/xUnitTests/xUnitTests.csproj
+          --no-build
+          --verbosity normal
+          --logger "trx;LogFileName=test-results.trx"
+          --filter "FullyQualifiedName\!~integrationTests"
+
+  report:
+    needs: build-test
+    if: github.event_name != 'pull_request'
+        || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload and annotate test results
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Results
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: 'true'
+

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp.meta
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 908235fdf5dc08a4c9c37247cdcfc16f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
@@ -29,7 +29,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 3000
   stringTagMap: {}
   disabledShaderPasses:
   - MOTIONVECTORS
@@ -114,13 +114,14 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Iterations: 2.276
+    - _Iterations: 1.173
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Size: 5
+    - _Samples: 7.17
+    - _Size: 2.9
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
@@ -141,7 +142,7 @@ Material:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _MultiplyColor: {r: 0.525, g: 0.525, b: 0.525, a: 0.53333336}
+    - _MultiplyColor: {r: 0.78699994, g: 0.7409521, b: 0.7409521, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
     - _TextureSampleAdd: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-253989385686868923
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BlurUrp
+  m_Shader: {fileID: 4800000, guid: a4714f3096a129d44a751f81e3c94ff2, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Size: 1.63
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _AdditiveColor: {r: 0.4245283, g: 0.29036134, b: 0.29036134, a: 1}
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _MultiplyColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
@@ -103,7 +103,7 @@ Material:
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
-    - _ColorMask: 15
+    - _ColorMask: 10.21
     - _Cull: 2
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
@@ -114,32 +114,35 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _Iterations: 2.276
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Size: 1.63
+    - _Size: 5
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
+    - _Stencil: 0.43
+    - _StencilComp: 7.17
+    - _StencilOp: 1.4
+    - _StencilReadMask: 226.7
+    - _StencilWriteMask: 256.18
     - _Surface: 0
+    - _UseUIAlphaClip: 0
     - _WorkflowMode: 1
     - _XRMotionVectorsPass: 1
     - _ZWrite: 1
     m_Colors:
-    - _AdditiveColor: {r: 0.4245283, g: 0.29036134, b: 0.29036134, a: 1}
+    - _AdditiveColor: {r: 0.426, g: 0.284142, b: 0.284142, a: 0.4509804}
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _MultiplyColor: {r: 1, g: 1, b: 1, a: 1}
+    - _MultiplyColor: {r: 0.525, g: 0.525, b: 0.525, a: 0.53333336}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+    - _TextureSampleAdd: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat
@@ -121,7 +121,7 @@ Material:
     - _QueueOffset: 0
     - _ReceiveShadows: 1
     - _Samples: 7.17
-    - _Size: 2.9
+    - _Size: 0.8
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat.meta
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a096c4694175d949bf38cda890fdfde
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
@@ -1,24 +1,33 @@
 Shader "Custom/BlurURP"
 {
-    Properties{
-        _Size           ("Blur Radius"           , Range(0,50)) = 5.0
-        _Samples        ("Sample Count"          , Range(4,32)) = 16
-        _MainTex        ("Mask Texture (Alpha)" , 2D)          = "white" {}
-        _MultiplyColor  ("Multiply Tint Color"  , Color)       = (1,1,1,1)
-        _AdditiveColor  ("Additive Tint Color"  , Color)       = (0,0,0,0)
+    Properties
+    {
+        _Size ("Blur Radius" , Range(0,50)) = 5.0
+        _Samples ("Sample Count" , Range(4,32)) = 16
+        _MainTex ("Mask Texture (Alpha)" , 2D) = "white" {}
+        _MultiplyColor ("Multiply Tint Color" , Color) = (1,1,1,1)
+        _AdditiveColor ("Additive Tint Color" , Color) = (0,0,0,0)
     }
 
-    SubShader{
-        Tags{ "Queue"="Transparent" "RenderType"="Transparent"
-              "RenderPipeline"="UniversalPipeline" }
+    SubShader
+    {
+        Tags
+        {
+            "Queue"="Transparent" "RenderType"="Transparent"
+            "RenderPipeline"="UniversalPipeline"
+        }
 
         Blend SrcAlpha OneMinusSrcAlpha
         ZWrite Off
         Cull Off
 
-        Pass{
+        Pass
+        {
             Name "ForwardBlur"
-            Tags{ "LightMode" = "SRPDefaultUnlit" }
+            Tags
+            {
+                "LightMode" = "SRPDefaultUnlit"
+            }
 
             HLSLPROGRAM
             #pragma vertex   vert
@@ -28,50 +37,74 @@ Shader "Custom/BlurURP"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             // -------- uniforms
-            sampler2D _MainTex;               float4 _MainTex_ST;
-            sampler2D _CameraOpaqueTexture;   float4 _CameraOpaqueTexture_TexelSize;
-            float    _Size;
-            int      _Samples;
-            float4   _MultiplyColor, _AdditiveColor;
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            sampler2D _CameraOpaqueTexture;
+            float4 _CameraOpaqueTexture_TexelSize;
+            sampler2D _CameraColorTexture;
+            float4 _CameraColorTexture_TexelSize;
+            float _Size;
+            int _Samples;
+            float4 _MultiplyColor, _AdditiveColor;
 
             // -------- vertex
-            struct appdata { float4 pos:POSITION; float2 uv:TEXCOORD0; };
-            struct v2f     { float4 pos:SV_POSITION; float2 uvMask:TEXCOORD0; float2 uvScreen:TEXCOORD1; };
+            struct appdata
+            {
+                float4 pos:POSITION;
+                float2 uv:TEXCOORD0;
+            };
 
-            v2f vert (appdata v){
+            struct v2f
+            {
+                float4 pos:SV_POSITION;
+                float2 uvMask:TEXCOORD0;
+                float2 uvScreen:TEXCOORD1;
+            };
+
+            v2f vert(appdata v)
+            {
                 v2f o;
-                o.pos       = TransformObjectToHClip(v.pos.xyz);
-                o.uvMask    = TRANSFORM_TEX(v.uv, _MainTex);
+                o.pos = TransformObjectToHClip(v.pos.xyz);
+                o.uvMask = TRANSFORM_TEX(v.uv, _MainTex);
 
-                float2 uv   = o.pos.xy / o.pos.w;
-            #if UNITY_UV_STARTS_AT_TOP
+                float2 uv = o.pos.xy / o.pos.w;
+                #if UNITY_UV_STARTS_AT_TOP
                 uv.y = -uv.y;
-            #endif
-                o.uvScreen  = uv * 0.5 + 0.5;
+                #endif
+                o.uvScreen = uv * 0.5 + 0.5;
                 return o;
             }
 
             // -------- fragment
-            half4 frag (v2f i) : SV_Target{
+            half4 frag(v2f i) : SV_Target
+            {
                 float2 texelSize = _CameraOpaqueTexture_TexelSize.xy;
                 half3 result = 0;
                 float totalWeight = 0;
-                
+
                 // Much stronger blur using circular sampling pattern
-                for(int x = -_Samples/2; x <= _Samples/2; x++) {
-                    for(int y = -_Samples/2; y <= _Samples/2; y++) {
+                for (int x = -_Samples / 2; x <= _Samples / 2; x++)
+                {
+                    for (int y = -_Samples / 2; y <= _Samples / 2; y++)
+                    {
                         float2 offset = float2(x, y) * _Size * texelSize;
                         float distance = length(offset);
-                        
+
                         // Gaussian weight based on distance
                         float weight = exp(-distance * distance * 0.5);
-                        
-                        half3 sample = tex2D(_CameraOpaqueTexture, i.uvScreen + offset).rgb;
-                        result += sample * weight;
+
+                        // Sample both opaque and color textures to include UI elements
+                        half4 opaqueSample = tex2D(_CameraOpaqueTexture, i.uvScreen + offset);
+                        half4 colorSample = tex2D(_CameraColorTexture, i.uvScreen + offset);
+
+                        // Blend the samples - use color texture if it has transparency info, otherwise opaque
+                        half3 finalSample = lerp(opaqueSample.rgb, colorSample.rgb, colorSample.a);
+
+                        result += finalSample * weight;
                         totalWeight += weight;
                     }
                 }
-                
+
                 // Normalize by total weight
                 half3 blur = result / totalWeight;
                 half3 tinted = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
@@ -1,0 +1,73 @@
+Shader "Custom/BlurURP"
+{
+    Properties{
+        _Size           ("Blur Radius"           , Range(0,40)) = 1.0
+        _MainTex        ("Mask Texture (Alpha)" , 2D)          = "white" {}
+        _MultiplyColor  ("Multiply Tint Color"  , Color)       = (1,1,1,1)
+        _AdditiveColor  ("Additive Tint Color"  , Color)       = (0,0,0,0)
+    }
+
+    SubShader{
+        Tags{ "Queue"="Transparent" "RenderType"="Transparent"
+              "RenderPipeline"="UniversalPipeline" }
+
+        Blend SrcAlpha OneMinusSrcAlpha
+        ZWrite Off
+        Cull Off
+
+        Pass{
+            Name "ForwardBlur"
+            Tags{ "LightMode" = "SRPDefaultUnlit" } // recognised by URP :contentReference[oaicite:2]{index=2}
+
+            HLSLPROGRAM
+            #pragma vertex   vert            // <-- NEW :contentReference[oaicite:3]{index=3}
+            #pragma fragment frag
+            #pragma target   3.0
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            // -------- uniforms
+            sampler2D _MainTex;               float4 _MainTex_ST;
+            sampler2D _CameraOpaqueTexture;   float4 _CameraOpaqueTexture_TexelSize;
+            float    _Size;
+            float4   _MultiplyColor, _AdditiveColor;
+
+            // -------- vertex
+            struct appdata { float4 pos:POSITION; float2 uv:TEXCOORD0; };
+            struct v2f     { float4 pos:SV_POSITION; float2 uvMask:TEXCOORD0; float2 uvScreen:TEXCOORD1; };
+
+            v2f vert (appdata v){
+                v2f o;
+                o.pos       = mul(UNITY_MATRIX_MVP, v.pos);
+                o.uvMask    = TRANSFORM_TEX(v.uv, _MainTex);
+
+                float2 uv   = o.pos.xy / o.pos.w;
+            #if UNITY_UV_STARTS_AT_TOP
+                uv.y = -uv.y;
+            #endif
+                o.uvScreen  = uv * 0.5 + 0.5;
+                return o;
+            }
+
+            // -------- fragment
+            half4 frag (v2f i) : SV_Target{
+                float2 t = _CameraOpaqueTexture_TexelSize.xy;
+                half  w[5] = { 0.18h, 0.15h, 0.12h, 0.09h, 0.05h };   // weights 0..4
+
+                // Horizontal + vertical blur (9 × 2 taps)
+                half3 sumH = 0, sumV = 0;
+                [unroll] for(int k=-4;k<=4;++k){
+                    int idx = abs(k);
+                    sumH += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(k*_Size*t.x,0)).rgb * w[idx];
+                    sumV += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(0,k*_Size*t.y)).rgb * w[idx];
+                }
+                half3 blur    = (sumH + sumV)*0.5;
+                half3 tinted  = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;
+                half  alpha   = tex2D(_MainTex, i.uvMask).a;
+                return half4(tinted, alpha);
+            }
+            ENDHLSL
+        }
+    }
+    FallBack Off
+}

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
@@ -1,8 +1,8 @@
 Shader "Custom/BlurURP"
 {
     Properties{
-        _Size           ("Blur Radius"           , Range(0,100)) = 1.0
-        _Iterations     ("Blur Iterations"       , Range(1,3)) = 1
+        _Size           ("Blur Radius"           , Range(0,50)) = 5.0
+        _Samples        ("Sample Count"          , Range(4,32)) = 16
         _MainTex        ("Mask Texture (Alpha)" , 2D)          = "white" {}
         _MultiplyColor  ("Multiply Tint Color"  , Color)       = (1,1,1,1)
         _AdditiveColor  ("Additive Tint Color"  , Color)       = (0,0,0,0)
@@ -18,10 +18,10 @@ Shader "Custom/BlurURP"
 
         Pass{
             Name "ForwardBlur"
-            Tags{ "LightMode" = "SRPDefaultUnlit" } // recognised by URP :contentReference[oaicite:2]{index=2}
+            Tags{ "LightMode" = "SRPDefaultUnlit" }
 
             HLSLPROGRAM
-            #pragma vertex   vert            // <-- NEW :contentReference[oaicite:3]{index=3}
+            #pragma vertex   vert
             #pragma fragment frag
             #pragma target   3.0
 
@@ -31,7 +31,7 @@ Shader "Custom/BlurURP"
             sampler2D _MainTex;               float4 _MainTex_ST;
             sampler2D _CameraOpaqueTexture;   float4 _CameraOpaqueTexture_TexelSize;
             float    _Size;
-            int      _Iterations;
+            int      _Samples;
             float4   _MultiplyColor, _AdditiveColor;
 
             // -------- vertex
@@ -53,43 +53,29 @@ Shader "Custom/BlurURP"
 
             // -------- fragment
             half4 frag (v2f i) : SV_Target{
-                float2 t = _CameraOpaqueTexture_TexelSize.xy;
-                
-                // Improved Gaussian weights for stronger blur (7 samples each direction)
-                half  w[7] = { 0.0044299121055113265h, 0.05399096651318806h, 0.2419707245191454h, 
-                              0.39894228040143267h, 0.2419707245191454h, 0.05399096651318806h, 0.0044299121055113265h };
-
+                float2 texelSize = _CameraOpaqueTexture_TexelSize.xy;
                 half3 result = 0;
+                float totalWeight = 0;
                 
-                // Multiple iterations for much stronger blur
-                for(int iter = 0; iter < _Iterations; iter++){
-                    float iterSize = _Size * (iter + 1);
-                    
-                    // Horizontal blur (13 samples)
-                    half3 sumH = 0;
-                    [unroll] for(int k=-6; k<=6; ++k){
-                        int idx = abs(k); 
-                        if(idx < 7){
-                            sumH += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(k*iterSize*t.x,0)).rgb * w[idx];
-                        }
+                // Much stronger blur using circular sampling pattern
+                for(int x = -_Samples/2; x <= _Samples/2; x++) {
+                    for(int y = -_Samples/2; y <= _Samples/2; y++) {
+                        float2 offset = float2(x, y) * _Size * texelSize;
+                        float distance = length(offset);
+                        
+                        // Gaussian weight based on distance
+                        float weight = exp(-distance * distance * 0.5);
+                        
+                        half3 sample = tex2D(_CameraOpaqueTexture, i.uvScreen + offset).rgb;
+                        result += sample * weight;
+                        totalWeight += weight;
                     }
-                    
-                    // Vertical blur (13 samples)
-                    half3 sumV = 0;
-                    [unroll] for(int k=-6; k<=6; ++k){
-                        int idx = abs(k);
-                        if(idx < 7){
-                            sumV += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(0,k*iterSize*t.y)).rgb * w[idx];
-                        }
-                    }
-                    
-                    result += (sumH + sumV) * 0.5;
                 }
                 
-                // Average across iterations
-                half3 blur = result / _Iterations;
-                half3 tinted  = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;
-                half  alpha   = tex2D(_MainTex, i.uvMask).a;
+                // Normalize by total weight
+                half3 blur = result / totalWeight;
+                half3 tinted = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;
+                half alpha = tex2D(_MainTex, i.uvMask).a;
                 return half4(tinted, alpha);
             }
             ENDHLSL

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
@@ -1,7 +1,8 @@
 Shader "Custom/BlurURP"
 {
     Properties{
-        _Size           ("Blur Radius"           , Range(0,40)) = 1.0
+        _Size           ("Blur Radius"           , Range(0,100)) = 1.0
+        _Iterations     ("Blur Iterations"       , Range(1,3)) = 1
         _MainTex        ("Mask Texture (Alpha)" , 2D)          = "white" {}
         _MultiplyColor  ("Multiply Tint Color"  , Color)       = (1,1,1,1)
         _AdditiveColor  ("Additive Tint Color"  , Color)       = (0,0,0,0)
@@ -30,6 +31,7 @@ Shader "Custom/BlurURP"
             sampler2D _MainTex;               float4 _MainTex_ST;
             sampler2D _CameraOpaqueTexture;   float4 _CameraOpaqueTexture_TexelSize;
             float    _Size;
+            int      _Iterations;
             float4   _MultiplyColor, _AdditiveColor;
 
             // -------- vertex
@@ -38,7 +40,7 @@ Shader "Custom/BlurURP"
 
             v2f vert (appdata v){
                 v2f o;
-                o.pos       = mul(UNITY_MATRIX_MVP, v.pos);
+                o.pos       = TransformObjectToHClip(v.pos.xyz);
                 o.uvMask    = TRANSFORM_TEX(v.uv, _MainTex);
 
                 float2 uv   = o.pos.xy / o.pos.w;
@@ -52,16 +54,40 @@ Shader "Custom/BlurURP"
             // -------- fragment
             half4 frag (v2f i) : SV_Target{
                 float2 t = _CameraOpaqueTexture_TexelSize.xy;
-                half  w[5] = { 0.18h, 0.15h, 0.12h, 0.09h, 0.05h };   // weights 0..4
+                
+                // Improved Gaussian weights for stronger blur (7 samples each direction)
+                half  w[7] = { 0.0044299121055113265h, 0.05399096651318806h, 0.2419707245191454h, 
+                              0.39894228040143267h, 0.2419707245191454h, 0.05399096651318806h, 0.0044299121055113265h };
 
-                // Horizontal + vertical blur (9 × 2 taps)
-                half3 sumH = 0, sumV = 0;
-                [unroll] for(int k=-4;k<=4;++k){
-                    int idx = abs(k);
-                    sumH += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(k*_Size*t.x,0)).rgb * w[idx];
-                    sumV += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(0,k*_Size*t.y)).rgb * w[idx];
+                half3 result = 0;
+                
+                // Multiple iterations for much stronger blur
+                for(int iter = 0; iter < _Iterations; iter++){
+                    float iterSize = _Size * (iter + 1);
+                    
+                    // Horizontal blur (13 samples)
+                    half3 sumH = 0;
+                    [unroll] for(int k=-6; k<=6; ++k){
+                        int idx = abs(k); 
+                        if(idx < 7){
+                            sumH += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(k*iterSize*t.x,0)).rgb * w[idx];
+                        }
+                    }
+                    
+                    // Vertical blur (13 samples)
+                    half3 sumV = 0;
+                    [unroll] for(int k=-6; k<=6; ++k){
+                        int idx = abs(k);
+                        if(idx < 7){
+                            sumV += tex2D(_CameraOpaqueTexture, i.uvScreen + float2(0,k*iterSize*t.y)).rgb * w[idx];
+                        }
+                    }
+                    
+                    result += (sumH + sumV) * 0.5;
                 }
-                half3 blur    = (sumH + sumV)*0.5;
+                
+                // Average across iterations
+                half3 blur = result / _Iterations;
                 half3 tinted  = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;
                 half  alpha   = tex2D(_MainTex, i.uvMask).a;
                 return half4(tinted, alpha);

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader
@@ -58,7 +58,7 @@ Shader "Custom/BlurURP"
             {
                 float4 pos:SV_POSITION;
                 float2 uvMask:TEXCOORD0;
-                float2 uvScreen:TEXCOORD1;
+                float4 screenPos:TEXCOORD1;
             };
 
             v2f vert(appdata v)
@@ -67,40 +67,39 @@ Shader "Custom/BlurURP"
                 o.pos = TransformObjectToHClip(v.pos.xyz);
                 o.uvMask = TRANSFORM_TEX(v.uv, _MainTex);
 
-                float2 uv = o.pos.xy / o.pos.w;
-                #if UNITY_UV_STARTS_AT_TOP
-                uv.y = -uv.y;
-                #endif
-                o.uvScreen = uv * 0.5 + 0.5;
+                // Use ComputeScreenPos for proper screen space coordinates
+                // This handles world space UI canvases correctly
+                o.screenPos = ComputeScreenPos(o.pos);
+
                 return o;
             }
 
             // -------- fragment
             half4 frag(v2f i) : SV_Target
             {
-                float2 texelSize = _CameraOpaqueTexture_TexelSize.xy;
+                // Convert screen position to UV coordinates
+                float2 uvScreen = i.screenPos.xy / i.screenPos.w;
+
                 half3 result = 0;
                 float totalWeight = 0;
 
-                // Much stronger blur using circular sampling pattern
+                // Blur sampling with simpler approach
                 for (int x = -_Samples / 2; x <= _Samples / 2; x++)
                 {
                     for (int y = -_Samples / 2; y <= _Samples / 2; y++)
                     {
-                        float2 offset = float2(x, y) * _Size * texelSize;
+                        float2 offset = float2(x, y) * _Size * _CameraOpaqueTexture_TexelSize.xy;
                         float distance = length(offset);
 
                         // Gaussian weight based on distance
                         float weight = exp(-distance * distance * 0.5);
 
-                        // Sample both opaque and color textures to include UI elements
-                        half4 opaqueSample = tex2D(_CameraOpaqueTexture, i.uvScreen + offset);
-                        half4 colorSample = tex2D(_CameraColorTexture, i.uvScreen + offset);
+                        float2 sampleUV = uvScreen + offset;
 
-                        // Blend the samples - use color texture if it has transparency info, otherwise opaque
-                        half3 finalSample = lerp(opaqueSample.rgb, colorSample.rgb, colorSample.a);
+                        // Sample the opaque texture (which should contain all rendered content including world space UI)
+                        half3 sample = tex2D(_CameraOpaqueTexture, sampleUV).rgb;
 
-                        result += finalSample * weight;
+                        result += sample * weight;
                         totalWeight += weight;
                     }
                 }
@@ -108,7 +107,7 @@ Shader "Custom/BlurURP"
                 // Normalize by total weight
                 half3 blur = result / totalWeight;
                 half3 tinted = blur * _MultiplyColor.rgb + _AdditiveColor.rgb;
-                half alpha = tex2D(_MainTex, i.uvMask).a;
+                half alpha = tex2D(_MainTex, i.uvMask).a * _MultiplyColor.a;
                 return half4(tinted, alpha);
             }
             ENDHLSL

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader.meta
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrp.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a4714f3096a129d44a751f81e3c94ff2
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity
@@ -1,0 +1,1854 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &242746365
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64202185543156367, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.99999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.194
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.688
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.019
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 713958371166046578, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.99999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1528783273361633594, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 146.78012
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2034288508194601671, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 244.52019
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2711567736772015522, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Name
+      value: CharacterUi3d
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5987757953490769592, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132974206367961051, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -0.79944426
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490989938887630149, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -1.9976848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7053592024639713101, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00029431487
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7443607709889834070, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.0002642375
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+--- !u!1 &249953028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 249953032}
+  - component: {fileID: 249953031}
+  - component: {fileID: 249953030}
+  - component: {fileID: 249953029}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &249953029
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249953028}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &249953030
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249953028}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7a096c4694175d949bf38cda890fdfde, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &249953031
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249953028}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &249953032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249953028}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.75100243, y: -0, z: -0, w: 0.6602995}
+  m_LocalPosition: {x: 5.21, y: 0.24951, z: -0.87}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: -97.355, y: 0, z: 0}
+--- !u!1 &516726025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 516726027}
+  - component: {fileID: 516726026}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &516726026
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516726025}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &516726027
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516726025}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &525783578
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64202185543156367, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 64202185543156367, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.616
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.552
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.842
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 713958371166046578, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 713958371166046578, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 860039466189040144, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a096c4694175d949bf38cda890fdfde, type: 2}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1528783273361633594, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 146.78035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2034288508194601671, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 244.52075
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2711567736772015522, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Name
+      value: CharacterUi3d (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2937729620524833361, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.9999969
+      objectReference: {fileID: 0}
+    - target: {fileID: 3344640513121491274, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.9999969
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5987757953490769592, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132974206367961051, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.4442585
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132974206367961051, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -0.0000031201516
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490989938887630149, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.6664067
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -0.000002702879
+      objectReference: {fileID: 0}
+    - target: {fileID: 7053592024639713101, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.000451909
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7443607709889834070, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.000451909
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.99999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+--- !u!1 &1275417898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1275417901}
+  - component: {fileID: 1275417900}
+  - component: {fileID: 1275417899}
+  - component: {fileID: 1275417902}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1275417899
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275417898}
+  m_Enabled: 1
+--- !u!20 &1275417900
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275417898}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1275417901
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275417898}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -3.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1275417902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275417898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!1 &1636490866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1636490867}
+  m_Layer: 0
+  m_Name: Singletons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1636490867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1636490866}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1970838558}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1921011112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1921011116}
+  - component: {fileID: 1921011115}
+  - component: {fileID: 1921011114}
+  - component: {fileID: 1921011113}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1921011113
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921011112}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1921011114
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921011112}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1921011115
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921011112}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1921011116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921011112}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.119}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1970838557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1970838558}
+  - component: {fileID: 1970838559}
+  m_Layer: 0
+  m_Name: com.csutil.ui.Theme
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1970838558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1970838557}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1636490867}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1970838559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1970838557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13e698eef320c2747ada784311781a7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  schemeName: Colors/colorScheme1
+  colors:
+  - colorName: accent
+    colorValue: {r: 0.99607843, g: 0.78039217, b: 0.42352942, a: 1}
+  - colorName: accentContrast
+    colorValue: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  - colorName: accentContrastWeak
+    colorValue: {r: 0.39607844, g: 0.39607844, b: 0.39607844, a: 1}
+  - colorName: primary
+    colorValue: {r: 0.03529412, g: 0.5529412, b: 0.85882354, a: 1}
+  - colorName: primaryContrast
+    colorValue: {r: 1, g: 1, b: 1, a: 1}
+  - colorName: primaryContrastWeak
+    colorValue: {r: 0.8784314, g: 0.8784314, b: 0.8784314, a: 1}
+  - colorName: background
+    colorValue: {r: 1, g: 1, b: 1, a: 1}
+  - colorName: backgroundContrast
+    colorValue: {r: 0.12941177, g: 0.12941177, b: 0.12941177, a: 1}
+  - colorName: backgroundContrastWeak
+    colorValue: {r: 0.45882353, g: 0.45882353, b: 0.45882353, a: 1}
+  - colorName: card
+    colorValue: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 1}
+  - colorName: cardDark
+    colorValue: {r: 0.9254902, g: 0.92941177, b: 0.9411765, a: 1}
+  - colorName: cardContrast
+    colorValue: {r: 0.12941177, g: 0.12941177, b: 0.12941177, a: 1}
+  - colorName: cardContrastWeak
+    colorValue: {r: 0.53333336, g: 0.53333336, b: 0.53333336, a: 1}
+  - colorName: transparent
+    colorValue: {r: 0, g: 0, b: 0, a: 0.8784314}
+  - colorName: transparentContrast
+    colorValue: {r: 1, g: 1, b: 1, a: 1}
+  - colorName: transparentContrastWeak
+    colorValue: {r: 0.8666667, g: 0.8666667, b: 0.8666667, a: 1}
+  - colorName: shadow
+    colorValue: {r: 0, g: 0, b: 0, a: 0.2}
+  - colorName: shadowContrast
+    colorValue: {r: 1, g: 1, b: 1, a: 1}
+  - colorName: shadowContrastWeak
+    colorValue: {r: 0.8666667, g: 0.8666667, b: 0.8666667, a: 1}
+  - colorName: warning
+    colorValue: {r: 0.9372549, g: 0.3254902, b: 0.3137255, a: 1}
+  - colorName: warningContrast
+    colorValue: {r: 1, g: 0.9019608, b: 0.9019608, a: 1}
+  - colorName: warningContrastWeak
+    colorValue: {r: 0.9372549, g: 0.73333335, b: 0.7294118, a: 1}
+  - colorName: element
+    colorValue: {r: 0.32941177, g: 0.34509805, b: 0.3882353, a: 1}
+  - colorName: elementLight
+    colorValue: {r: 0.64705884, g: 0.67058825, b: 0.7607843, a: 1}
+  - colorName: elementContrast
+    colorValue: {r: 0.92941177, g: 0.92941177, b: 0.92941177, a: 1}
+  - colorName: elementContrastWeak
+    colorValue: {r: 0.6509804, g: 0.6509804, b: 0.6509804, a: 1}
+  - colorName: button
+    colorValue: {r: 0.2901961, g: 0.3019608, b: 0.34117648, a: 1}
+  - colorName: buttonContrast
+    colorValue: {r: 1, g: 1, b: 1, a: 1}
+  - colorName: buttonContrastWeak
+    colorValue: {r: 0.8666667, g: 0.8666667, b: 0.8666667, a: 1}
+  doAutomaticRuntimeColorUpdates: 0
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1275417901}
+  - {fileID: 516726027}
+  - {fileID: 1921011116}
+  - {fileID: 249953032}
+  - {fileID: 1636490867}
+  - {fileID: 242746365}
+  - {fileID: 525783578}

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity
@@ -263,9 +263,33 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1528783273361633594, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 146.78012
+      value: 146.78001
       objectReference: {fileID: 0}
     - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -317,7 +341,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2034288508194601671, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 244.52019
+      value: 244.52003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -479,13 +527,37 @@ PrefabInstance:
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_Value
       value: -1.9976848
       objectReference: {fileID: 0}
     - target: {fileID: 7053592024639713101, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.00029431487
+      value: 0.00004008343
       objectReference: {fileID: 0}
     - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -537,7 +609,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7443607709889834070, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.0002642375
+      value: -0.0000005647358
       objectReference: {fileID: 0}
     - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.x
@@ -547,12 +619,40 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
@@ -1020,7 +1120,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1528783273361633594, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 146.78035
+      value: 146.78004
       objectReference: {fileID: 0}
     - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1072,7 +1172,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2034288508194601671, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 244.52075
+      value: 244.51999
       objectReference: {fileID: 0}
     - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1304,7 +1404,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7053592024639713101, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000451909
+      value: 0.00002721748
       objectReference: {fileID: 0}
     - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1356,7 +1456,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7443607709889834070, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000451909
+      value: 0.00002721748
       objectReference: {fileID: 0}
     - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1409,6 +1509,647 @@ PrefabInstance:
     - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_Size
       value: 0.99999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9058707424419357049, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166858010951380902, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180099579689637432, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+--- !u!1001 &772167575
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54466242425579885, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64202185543156367, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 64202185543156367, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197623885203080114, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3.205484
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.367
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.487
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.497
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 251187950033995019, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 380552040568170392, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 713958371166046578, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 713958371166046578, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 842862761715681359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 860039466189040144, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a096c4694175d949bf38cda890fdfde, type: 2}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1294104162448953843, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310507415665883096, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1528783273361633594, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 146.78043
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1799749034794129934, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1868523042707659254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2034288508194601671, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 244.52031
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281625398716718338, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614484571196934428, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2711567736772015522, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Name
+      value: CharacterUi3d (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884286205735584613, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2937729620524833361, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.999949
+      objectReference: {fileID: 0}
+    - target: {fileID: 3344640513121491274, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.999949
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3362339890360991870, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717651141961241201, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3826867063853404754, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223156900779432332, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5987757953490769592, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012644552855475700, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132974206367961051, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.4442477
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132974206367961051, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -0.0000009984485
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6226398623971037614, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490989938887630149, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520471784372641289, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521922607661472398, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 0.6663715
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634041243731772454, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: -0.000002910793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7053592024639713101, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00067676447
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7230141044078036118, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280389438214713301, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7443607709889834070, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00067676447
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411198804181379716, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8647863807549073359, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8775306449579873571, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8904224306978100254, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
+      propertyPath: m_Size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9024172972904945413, guid: 9a4d32c6fd9893e4dbd131603da2a972, type: 3}
       propertyPath: m_Value
@@ -1852,3 +2593,4 @@ SceneRoots:
   - {fileID: 1636490867}
   - {fileID: 242746365}
   - {fileID: 525783578}
+  - {fileID: 772167575}

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity.meta
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/BlurUrp/BlurUrpTests.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c341c85edd2cb94b9c0412979645b48
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/jsonschema/JsonModelExtensions.cs
+++ b/CsCore/CsCoreUnity/Plugins/CsCoreUnity/com/csutil/ui/jsonschema/JsonModelExtensions.cs
@@ -210,7 +210,7 @@ namespace com.csutil.ui.jsonschema {
 
         private static void SetupButtons(ListFieldView listView, JObject root, JsonSchemaToView viewGenerator, JArray modelArray, Dictionary<FieldView, JToken> map) {
             listView.add.SetOnClickAction(async delegate {
-                JToken entry = listView.field.items.First().NewDefaultJInstance();
+                JToken entry = listView.field.items.anyOf.First().NewDefaultJInstance();
                 modelArray.Add(entry);
                 var fieldName = "" + (modelArray.Count - 1);
                 var fv = await CreateChildEntryView(listView, root, viewGenerator, entry, fieldName);
@@ -256,7 +256,7 @@ namespace com.csutil.ui.jsonschema {
 
         private static async Task<FieldView> CreateChildEntryView(
                 ListFieldView self, JObject root, JsonSchemaToView viewGenerator, JToken modelEntry, string fieldName) {
-            JsonSchema newEntryVm = GetMatchingSchema(modelEntry, self.field.items);
+            JsonSchema newEntryVm = GetMatchingSchema(modelEntry, self.field.items.anyOf);
             GameObject childView = await AddChildEntryView(self, viewGenerator, fieldName, newEntryVm);
             await childView.LinkToJsonModel(root, viewGenerator);
             return childView.GetComponentInChildren<FieldView>();

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/EnumExtensions.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/EnumExtensions.cs
@@ -69,7 +69,7 @@ namespace com.csutil {
                 if (entryAsInt == 0) { continue; } // 0 is always a power of two
                 if ((entryAsInt & (entryAsInt - 1)) != 0) { // Check if the entry is a power of two:
                     var enumType = typeof(T);
-                    if (!onBlacklist(enumType)) {
+                    if (!IsOnBlacklist(enumType)) {
                         Log.w($"Enum {enumType} cant be used with .ContainsFlag() because not all entries are a power of two, e.g. {entry}={entryAsInt}! "
                             + $"This error should only be ignored if you have enum entries that are composed from other enum entries (eg MyEnum.A = MyEnum.B | MyEnum.C)");
                     }
@@ -77,7 +77,7 @@ namespace com.csutil {
             }
         }
         
-        private static bool onBlacklist(Type enumType) {
+        private static bool IsOnBlacklist(Type enumType) {
             // Anything in the System namespace is on the blacklist, as the dev has no control over these enums anyways:
             if (enumType.Namespace.StartsWith("System")) { return true; }
             // Add more types to the blacklist here if needed

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/EnumExtensions.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/extensions/EnumExtensions.cs
@@ -68,10 +68,20 @@ namespace com.csutil {
                 int entryAsInt = (int)(object)entry;
                 if (entryAsInt == 0) { continue; } // 0 is always a power of two
                 if ((entryAsInt & (entryAsInt - 1)) != 0) { // Check if the entry is a power of two:
-                    Log.w($"Enum {typeof(T)} cant be used with .ContainsFlag() because not all entries are a power of two, e.g. {entry}={entryAsInt}! "
-                        + $"This error should only be ignored if you have enum entries that are composed from other enum entries (eg MyEnum.A = MyEnum.B | MyEnum.C)");
+                    var enumType = typeof(T);
+                    if (!onBlacklist(enumType)) {
+                        Log.w($"Enum {enumType} cant be used with .ContainsFlag() because not all entries are a power of two, e.g. {entry}={entryAsInt}! "
+                            + $"This error should only be ignored if you have enum entries that are composed from other enum entries (eg MyEnum.A = MyEnum.B | MyEnum.C)");
+                    }
                 }
             }
+        }
+        
+        private static bool onBlacklist(Type enumType) {
+            // Anything in the System namespace is on the blacklist, as the dev has no control over these enums anyways:
+            if (enumType.Namespace.StartsWith("System")) { return true; }
+            // Add more types to the blacklist here if needed
+            return false; 
         }
 
         public static string GetEntryName<T>(this T entry) where T : struct

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
@@ -443,6 +443,14 @@ namespace com.csutil.http.apis {
             self.response_format = ChatGpt.Request.ResponseFormat.NewJsonSchema(schemaName, jsonSchema);
         }
         
+        public static void SetResponseFormatToJsonSchema<T>(this ChatGpt.Request self) {
+            ModelToJsonSchema schemaGenerator = new ModelToJsonSchema(nullValueHandling: NullValueHandling.Ignore);
+            Type type = typeof(T);
+            string className = type.Name;
+            JsonSchema jsonSchema = schemaGenerator.ToJsonSchema(className, type);
+            self.response_format = ChatGpt.Request.ResponseFormat.NewJsonSchema(className, jsonSchema);
+        }
+        
         public static JsonSchema CreateJsonSchema<T>(T exampleResponse) {
             var schemaGenerator = new ModelToJsonSchema(nullValueHandling: NullValueHandling.Ignore);
             var className = typeof(T).Name;

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
@@ -212,11 +212,6 @@ namespace com.csutil.http.apis {
             /// <summary> https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature </summary>
             public double? temperature { get; set; }
 
-            /// <summary> The maximum number of tokens to generate in the completion.
-            /// The token count of your prompt plus max_tokens cannot exceed the model's context length.
-            /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096). </summary>
-            public int max_tokens { get; set; }
-
             /// <summary> Number of desired <see cref="Response.choices"/> to be returned, defaults to 1.
             /// See also https://platform.openai.com/docs/api-reference/chat/create#chat-create-n </summary>
             public int? n { get; set; } = null;
@@ -232,13 +227,8 @@ namespace com.csutil.http.apis {
             /// <summary> typically null, but if the AI e.g. should respond only with json it should be ChatGpt.Request.ResponseFormat.json </summary>
             public ResponseFormat response_format { get; set; }
 
-            public Request(List<Message> messages, int max_tokens = 4096) {
-                var tokenCountForMessages = JsonWriter.GetWriter(this).Write(messages).Length;
-                if (max_tokens + tokenCountForMessages > 4096) {
-                    max_tokens = 4096 - tokenCountForMessages;
-                }
+            public Request(List<Message> messages) {
                 this.messages = messages;
-                this.max_tokens = max_tokens;
             }
 
             /// <summary> https://platform.openai.com/docs/guides/audio/quickstart?audio-generation-quickstart-example=audio-out </summary>

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/http/apis/OpenAi.cs
@@ -212,6 +212,13 @@ namespace com.csutil.http.apis {
             /// <summary> https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature </summary>
             public double? temperature { get; set; }
 
+            /// <summary>
+            /// An upper bound for the number of tokens that can be generated for a completion,
+            /// including visible output tokens and reasoning tokens. See also
+            /// https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens
+            /// </summary>
+            public int? max_completion_tokens { get; set; } = null;
+            
             /// <summary> Number of desired <see cref="Response.choices"/> to be returned, defaults to 1.
             /// See also https://platform.openai.com/docs/api-reference/chat/create#chat-create-n </summary>
             public int? n { get; set; } = null;
@@ -362,20 +369,18 @@ namespace com.csutil.http.apis {
             /// <summary> See https://beta.openai.com/docs/models/overview </summary>
             public string model = "gpt-4o";
 
-            /// <summary> The maximum number of tokens to generate in the completion.
-            /// The token count of your prompt plus max_tokens cannot exceed the model's context length.
-            /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096). </summary>
-            public int max_tokens { get; set; }
+            /// <summary>
+            /// An upper bound for the number of tokens that can be generated for a completion,
+            /// including visible output tokens and reasoning tokens. See also
+            /// https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens
+            /// </summary>
+            public int? max_completion_tokens { get; set; } = null;
             public List<Line> messages { get; set; }
 
-            public Request(List<Line> messages, int max_tokens = 4096) {
-                var tokenCountForMessages = JsonWriter.GetWriter(this).Write(messages).Length;
-                if (max_tokens + tokenCountForMessages > 4096) {
-                    max_tokens = 4096 - tokenCountForMessages;
-                }
+            public Request(List<Line> messages) {
                 this.messages = messages;
-                this.max_tokens = max_tokens;
             }
+            
         }
 
         public class Response {

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/RegexTemplates.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/RegexTemplates.cs
@@ -46,7 +46,7 @@ namespace com.csutil.model {
 
     public static class RegexUtil {
 
-        private static Regex camelCaseSplitter = new Regex(@"(\B[A-Z]+?(?=[A-Z][^A-Z])|\B[A-Z]+?(?=[^A-Z]))");
+        private static Regex camelCaseSplitter = new Regex(@"(\B[A-Z]+?(?=[A-Z][^A-Z_])|\B[A-Z]+?(?=[^A-Z_]))", RegexOptions.Compiled);
 
         public static string SplitCamelCaseString(string camelCaseString) {
             return camelCaseSplitter.Replace(camelCaseString, " $1").ToFirstCharUpperCase();

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/RegexTemplates.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/RegexTemplates.cs
@@ -46,10 +46,10 @@ namespace com.csutil.model {
 
     public static class RegexUtil {
 
-        private static Regex camelCaseSplitter = new Regex(@"(\B[A-Z]+?(?=[A-Z][^A-Z_])|\B[A-Z]+?(?=[^A-Z_]))", RegexOptions.Compiled);
+        private static Regex camelCaseSplitter = new Regex(@"(?<!^)(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])|(?<=[A-Za-z])(?=[0-9])|(?<=[0-9])(?=[A-Za-z])", RegexOptions.Compiled);
 
         public static string SplitCamelCaseString(string camelCaseString) {
-            return camelCaseSplitter.Replace(camelCaseString, " $1").ToFirstCharUpperCase();
+            return camelCaseSplitter.Replace(camelCaseString, " $0").ToFirstCharUpperCase();
         }
 
         /// <summary> Combines multiple regex via AND </summary>

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/ExpensiveRegularAsyncTaskInBackground.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/ExpensiveRegularAsyncTaskInBackground.cs
@@ -37,19 +37,19 @@ namespace com.csutil.model.ecs {
             }
         }
 
-        public async Task WaitTillDone() {
+        public async Task WaitTillDone(int millisecondsDelay = 10) {
             while (!runningTasks.IsEmpty || !waitingTasks.IsEmpty) {
                 var tasksToWaitFor = runningTasks.Values;
                 if (tasksToWaitFor.IsEmpty()) {
                     // If there are no running tasks but still waiting tasks,
                     // a short delay is needed to allow the system to schedule the next task.
-                    await Task.Delay(10);
+                    await TaskV2.Delay(millisecondsDelay);
                 } else {
                     await Task.WhenAll(tasksToWaitFor);
                 }
             }
         }
-        
+
     }
 
 }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/ExpensiveRegularAsyncTaskInBackground.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/ExpensiveRegularAsyncTaskInBackground.cs
@@ -36,6 +36,20 @@ namespace com.csutil.model.ecs {
                 return Task.CompletedTask;
             }
         }
+
+        public async Task WaitTillDone() {
+            while (!runningTasks.IsEmpty || !waitingTasks.IsEmpty) {
+                var tasksToWaitFor = runningTasks.Values;
+                if (tasksToWaitFor.IsEmpty()) {
+                    // If there are no running tasks but still waiting tasks,
+                    // a short delay is needed to allow the system to schedule the next task.
+                    await Task.Delay(10);
+                } else {
+                    await Task.WhenAll(tasksToWaitFor);
+                }
+            }
+        }
+        
     }
 
 }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/TemplatesIO.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/TemplatesIO.cs
@@ -92,8 +92,8 @@ namespace com.csutil.model.ecs {
             });
         }
 
-        public Task WaitForAllSavedChanges() { return _taskQueue.WaitTillDone(); }
-        
+        public Task WaitForAllSavedChanges(int millisecondsDelay = 10) { return _taskQueue.WaitTillDone(millisecondsDelay); }
+
         // [Conditional("DEBUG")]
         // private void LogSaveChangesIfThereIsAQueue(T instance) {
         //     if (_taskQueue.GetRemainingScheduledTaskCount() % 50 == 0) {

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/TemplatesIO.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/ecs/TemplatesIO.cs
@@ -92,6 +92,8 @@ namespace com.csutil.model.ecs {
             });
         }
 
+        public Task WaitForAllSavedChanges() { return _taskQueue.WaitTillDone(); }
+        
         // [Conditional("DEBUG")]
         // private void LogSaveChangesIfThereIsAQueue(T instance) {
         //     if (_taskQueue.GetRemainingScheduledTaskCount() % 50 == 0) {

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/BaseJsonSchemaToView.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/BaseJsonSchemaToView.cs
@@ -63,8 +63,8 @@ namespace com.csutil.model.jsonschema {
             }
             if (type == JTokenType.Array) {
                 var e = field.items;
-                if (e.Count == 1) {
-                    JsonSchema item = e.First();
+                if (e.anyOf.Count == 1) {
+                    JsonSchema item = e.anyOf.First();
                     var childJType = item.GetJTokenType();
                     if (schemaGenerator.IsSimpleType(childJType)) {
                         return await AddAndInit(parentView, field, fieldName, await NewListFieldView(field));

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
@@ -64,7 +64,7 @@ namespace com.csutil.model.jsonschema {
 
         /// <summary> If the field is an object it has a view model itself, see also
         /// https://json-schema.org/understanding-json-schema/reference/array.html#items </summary>
-        public List<JsonSchema> items;
+        public Items items;
 
         /// <summary> If true items is a set so it can only contain unique items, see also
         /// https://json-schema.org/understanding-json-schema/reference/array.html#uniqueness </summary>
@@ -88,6 +88,13 @@ namespace com.csutil.model.jsonschema {
             words2 = words2.Where(x => !x.IsNullOrEmpty());
             return string.Join(" ", words2.Select(x => x.First().ToString().ToUpper() + x.Substring(1)));
         }
+
+    }
+
+    public class Items {
+
+        /// <summary> The instance is valid if it matches at least one of the listed schemas. Multiple matches are fine </summary>
+        public List<JsonSchema> anyOf;
 
     }
 

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace com.csutil.model.jsonschema {
 
@@ -79,10 +79,15 @@ namespace com.csutil.model.jsonschema {
         /// https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values </summary>
         [JsonProperty("enum")]
         public string[] contentEnum;
-        
+
         public bool additionalProperties;
 
-        public static string ToTitle(string varName) { return RegexUtil.SplitCamelCaseString(varName); }
+        public static string ToTitle(string varName) {
+            var words = RegexUtil.SplitCamelCaseString(varName).Split(' ');
+            var words2 = words.SelectMany(x => x.Split('_'));
+            words2 = words2.Where(x => !x.IsNullOrEmpty());
+            return string.Join(" ", words2.Select(x => x.First().ToString().ToUpper() + x.Substring(1)));
+        }
 
     }
 

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
@@ -86,7 +86,10 @@ namespace com.csutil.model.jsonschema {
             var words = RegexUtil.SplitCamelCaseString(varName).Split(' ');
             var words2 = words.SelectMany(x => x.Split('_'));
             words2 = words2.Where(x => !x.IsNullOrEmpty());
-            return string.Join(" ", words2.Select(x => x.First().ToString().ToUpper() + x.Substring(1)));
+            return string.Join(" ", words2.Select(x => {
+                if (x.Length > 1) { return x.First().ToString().ToUpper() + x.Substring(1); }
+                return x;
+            }));
         }
 
     }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/JsonSchema.cs
@@ -83,13 +83,11 @@ namespace com.csutil.model.jsonschema {
         public bool additionalProperties;
 
         public static string ToTitle(string varName) {
-            var words = RegexUtil.SplitCamelCaseString(varName).Split(' ');
-            var words2 = words.SelectMany(x => x.Split('_'));
-            words2 = words2.Where(x => !x.IsNullOrEmpty());
-            return string.Join(" ", words2.Select(x => {
-                if (x.Length > 1) { return x.First().ToString().ToUpper() + x.Substring(1); }
-                return x;
-            }));
+            var words = RegexUtil.SplitCamelCaseString(varName)
+                .Split(' ').SelectMany(x => x.Split('_'))
+                .Where(x => !x.IsNullOrEmpty())
+                .Select(x => char.ToUpper(x[0]) + x.Substring(1));
+            return string.Join(" ", words);
         }
 
     }

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
@@ -71,6 +71,7 @@ namespace com.csutil.model.jsonschema {
             }
             var req = schema.properties.Filter(f => f.Value.mandatory == true).Map(f => f.Key);
             if (!req.IsNullOrEmpty()) { schema.required = req.ToList(); }
+            schema.description = modelType.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(true)?.Description;
             return schema;
         }
 

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
@@ -216,6 +216,10 @@ namespace com.csutil.model.jsonschema {
                 return true;
             }
             if (IsSimpleType(t)) {
+                if (modelType != null && modelType.IsEnum) {
+                    // For enum types never include a description
+                    return false;
+                }
                 if (pInstance != null && m != null) {
                     var value = m.GetValue(pInstance);
                     field.description = $"e.g. '{value}'";
@@ -228,8 +232,7 @@ namespace com.csutil.model.jsonschema {
                     return true;
                 }
                 if (t == JTokenType.Integer) {
-                    if (modelType != null && modelType.IsEnum) { return false; }
-                    field.description = "e.g. 99";
+                    field.description = "e.g. 1234";
                     return true;
                 }
                 if (t == JTokenType.Float) {

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
@@ -31,6 +31,7 @@ namespace com.csutil.model.jsonschema {
         public ModelToJsonSchema(NullValueHandling nullValueHandling) {
             var jsonSettings = JsonNetSettings.defaultSettings;
             jsonSettings.NullValueHandling = nullValueHandling;
+            jsonSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
             jsonSerializer = JsonSerializer.Create(jsonSettings);
         }
 
@@ -275,7 +276,7 @@ namespace com.csutil.model.jsonschema {
             if (elemType.IsCastableTo<string>()) { return JTokenType.String; }
             if (elemType.IsCastableTo<IDictionary>()) { return JTokenType.Object; }
             if (elemType.IsCastableTo<IEnumerable>()) { return JTokenType.Array; }
-            if (elemType.IsEnum) { return JTokenType.Integer; }
+            if (elemType.IsEnum) { return JTokenType.String; }
             return JTokenType.Object;
         }
 

--- a/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
+++ b/CsCore/PlainNetClassLib/src/Plugins/CsCore/com/csutil/model/jsonschema/ModelToJsonSchema.cs
@@ -178,18 +178,20 @@ namespace com.csutil.model.jsonschema {
                             var firstChildInstance = childrenInstances?.FirstOrDefault();
                             var childVm = new JsonSchema() { type = arrayElemJType.ToJsonSchemaType() };
                             SetupInnerJsonSchema(childVm, listElemType, firstChildInstance);
-                            newField.items = new List<JsonSchema>() { childVm };
+                            newField.items = new Items { anyOf = new List<JsonSchema>() { childVm } };
                         } else {
-                            newField.items = new List<JsonSchema>();
+                            newField.items = new Items { anyOf = new List<JsonSchema>() };
                             foreach (var child in childrenInstances) {
                                 var childVm = new JsonSchema() { type = arrayElemJType.ToJsonSchemaType() };
                                 SetupInnerJsonSchema(childVm, child.GetType(), child);
-                                newField.items.Add(childVm);
+                                newField.items.anyOf.Add(childVm);
                             }
-                            AssertV3.AreEqual(childrenInstances.Length, newField.items.Count);
+                            AssertV3.AreEqual(childrenInstances.Length, newField.items.anyOf.Count);
                         }
                     } else {
-                        newField.items = new List<JsonSchema>() { new JsonSchema() { type = arrayElemJType.ToJsonSchemaType() } };
+                        newField.items = new Items {
+                            anyOf = new List<JsonSchema>() { new JsonSchema() { type = arrayElemJType.ToJsonSchemaType() } }
+                        };
                     }
                 }
             }

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/http/apis/OpenAiTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/http/apis/OpenAiTests.cs
@@ -178,7 +178,11 @@ namespace com.csutil.integrationTests.http {
 
             var request = new ChatGpt.Request(messages);
             // Create an example object so that the AI knows how the response json should look like for user inputs:
-            var exampleResponse = new JsonSchemaExampleClass() { emotionOfResponse2 = JsonSchemaExampleClass.Emotion.happy };
+            var exampleResponse = new JsonSchemaExampleClass() {
+                emotionOfResponse2 = JsonSchemaExampleClass.Emotion.happy,
+                listOfStrings = new List<string> { "string1", "string2" },
+                listOfEnums = new List<JsonSchemaExampleClass.Emotion> { JsonSchemaExampleClass.Emotion.happy, JsonSchemaExampleClass.Emotion.sad }
+            };
             request.SetResponseFormatToJsonSchema(exampleResponse); // Use json schema as the response format
 
             await SendStrictJsonSchemaRequestToOpenAi(request, openAi);
@@ -190,8 +194,8 @@ namespace com.csutil.integrationTests.http {
             var response = await openAi.ChatGpt(request);
             ChatGpt.Message newLine = response.choices.Single().message;
             var parsedResponse = newLine.ParseNewLineContentAsJson<JsonSchemaExampleClass>();
-            Log.d(parsedResponse.emotionOfResponse.ToString());
             Assert.NotNull(parsedResponse.emotionOfResponse2);
+            Log.d(JsonWriter.AsPrettyString(parsedResponse));
         }
 
         private class JsonSchemaExampleClass {
@@ -203,7 +207,13 @@ namespace com.csutil.integrationTests.http {
             public Emotion? emotionOfResponse2;
 
             public enum Emotion { happy = 0, sad = 2, angry = 4, neutral = 8 }
+            
+            [System.ComponentModel.DataAnnotations.Required]
+            public List<string> listOfStrings;
 
+            [System.ComponentModel.DataAnnotations.Required]
+            public List<Emotion> listOfEnums;
+            
         }
 
         #if RUN_EXPENSIVE_TESTS

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/http/apis/OpenAiTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/http/apis/OpenAiTests.cs
@@ -155,6 +155,34 @@ namespace com.csutil.integrationTests.http {
             }
         }
 
+        [Fact]
+        public async Task ExampleUsage3_StrictJsonSchemaResponses2() {
+            // This tests tests additional json schema features like enums, arrays, ..
+            var openAi = new OpenAi(await IoC.inject.GetAppSecrets().GetSecret("OpenAiKey"));
+            var messages = new List<ChatGpt.Message>();
+            messages.Add(new ChatGpt.Message(ChatGpt.Role.system, content: "You are a helpful assistant designed to output JSON."));
+
+            // Create an example object so that the AI knows how the response json should look like for user inputs:
+            var exampleInstance = new JsonSchemaExampleClass() { emotionOfResponse = JsonSchemaExampleClass.Emotion.happy };
+            var request = NewGpt4StrictJsonRequestWithFullConversation(messages, exampleInstance);
+
+            Log.d("JSON schema of required response_format:\n" + JsonWriter.AsPrettyString(request.response_format));
+            var response = await openAi.ChatGpt(request);
+            ChatGpt.Message newLine = response.choices.Single().message;
+            var parsedResponse = newLine.ParseNewLineContentAsJson<JsonSchemaExampleClass>();
+            Log.d(parsedResponse.emotionOfResponse.ToString());
+
+        }
+
+        private class JsonSchemaExampleClass {
+            
+            [System.ComponentModel.DataAnnotations.Required]
+            public Emotion emotionOfResponse;
+            
+            public enum Emotion { happy = 0, sad = 2, angry = 4, neutral = 8 }
+            
+        }
+
         #if RUN_EXPENSIVE_TESTS
         [Fact]
         #endif

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/esc/EntityComponentSystemTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/esc/EntityComponentSystemTests.cs
@@ -26,7 +26,7 @@ namespace com.csutil.tests.model.esc {
             templatesDir.DeleteV2();
             templatesDir.CreateV2();
 
-            var templates = newTemplatesIO<Entity>(templatesDir);
+            TemplatesIO<Entity> templates = newTemplatesIO<Entity>(templatesDir);
 
             var enemyTemplate = new Entity() {
                 LocalPose = Matrix4x4.CreateTranslation(1, 2, 3),
@@ -64,7 +64,8 @@ namespace com.csutil.tests.model.esc {
                 Assert.Equal(instance3.TemplateId, instance4.TemplateId);
                 Assert.NotEqual(instance3.Id, instance4.Id);
             }
-            await TaskV2.Delay(100);
+            
+            await templates.WaitForAllSavedChanges();
             var ecs2 = newTemplatesIO<Entity>(templatesDir);
 
             var ids = ecs2.GetAllEntityIds().ToList();

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
@@ -164,6 +164,21 @@ namespace com.csutil.tests.model.jsonschema {
 
         }
 
+        [Fact]
+                public void TestGetJsonFieldName() {
+                    var model = new JsonFieldNameTestModel();
+                    var schemaGenerator = new ModelToJsonSchema();
+                    var schema = schemaGenerator.ToJsonSchema(nameof(JsonFieldNameTestModel), model);
+                    
+                    Assert.True(schema.properties.ContainsKey("custom_name"));
+                    Assert.True(schema.properties.ContainsKey("fieldWithoutAttribute"));
+                    
+                    Assert.Equal("Custom Name", schema.properties["custom_name"].title);
+                    Assert.Equal("Field Without Attribute", schema.properties["fieldWithoutAttribute"].title);
+                }
+        
+                
+        
         /// <summary>
         /// The following test uses the validator of System.ComponentModel to validate the model / object instance
         /// fields have values that are within the defined limits (enforced via the annotations on the model fields)
@@ -288,6 +303,15 @@ namespace com.csutil.tests.model.jsonschema {
 
             [Enum("Level of experience 5", "Beginner", "Avg", "Expert")]
             public int experience5;
+
+        }
+
+        private class JsonFieldNameTestModel {
+
+            [JsonProperty("custom_name")]
+            public string Name { get; set; }
+
+            public string fieldWithoutAttribute { get; set; }
 
         }
 

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
@@ -39,8 +39,8 @@ namespace com.csutil.tests.model.jsonschema {
             Assert.Equal(2, schema.required.Count);
 
             Assert.Equal("array", schema.properties["tags"].type);
-            Assert.Equal("string", schema.properties["tags"].items.First().type);
-            Assert.Null(schema.properties["tags"].items.First().properties);
+            Assert.Equal("string", schema.properties["tags"].items.anyOf.First().type);
+            Assert.Null(schema.properties["tags"].items.anyOf.First().properties);
 
             Assert.Equal("array", schema.properties["contacts"].type);
             Assert.True(schema.properties["id"].readOnly.Value); // id has private setter
@@ -48,11 +48,11 @@ namespace com.csutil.tests.model.jsonschema {
 
             Assert.Equal(30, schema.properties["name"].maxLength);
 
-            Assert.Equal("object", schema.properties["contacts"].items.First().type);
+            Assert.Equal("object", schema.properties["contacts"].items.anyOf.First().type);
             // Contacts schema already resolve as part of the bestFried field, so here no properties are included:
-            Assert.Null(schema.properties["contacts"].items.First().properties);
+            Assert.Null(schema.properties["contacts"].items.anyOf.First().properties);
 
-            var entrySchema = schema.properties["contacts"].items.First();
+            var entrySchema = schema.properties["contacts"].items.anyOf.First();
             Assert.Equal("" + typeof(MyUserModel.UserContact), entrySchema.modelType);
             Assert.Null(entrySchema.properties);
 
@@ -120,7 +120,7 @@ namespace com.csutil.tests.model.jsonschema {
             Log.d(JsonWriter.AsPrettyString(schema));
 
             Assert.Equal("Age", schema.properties["user"].properties["age"].title);
-            Assert.Equal("integer", schema.properties["phoneNumbers"].items.First().type);
+            Assert.Equal("integer", schema.properties["phoneNumbers"].items.anyOf.First().type);
 
         }
 

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
@@ -165,20 +165,39 @@ namespace com.csutil.tests.model.jsonschema {
         }
 
         [Fact]
-                public void TestGetJsonFieldName() {
-                    var model = new JsonFieldNameTestModel();
-                    var schemaGenerator = new ModelToJsonSchema();
-                    var schema = schemaGenerator.ToJsonSchema(nameof(JsonFieldNameTestModel), model);
-                    
-                    Assert.True(schema.properties.ContainsKey("custom_name"));
-                    Assert.True(schema.properties.ContainsKey("fieldWithoutAttribute"));
-                    
-                    Assert.Equal("Custom Name", schema.properties["custom_name"].title);
-                    Assert.Equal("Field Without Attribute", schema.properties["fieldWithoutAttribute"].title);
-                }
-        
-                
-        
+        public void TestToTitleHelperMethod() {
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("CustomName"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("customName"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("Custom_Name"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("Custom_name"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("_Custom_name"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("_custom_name"));
+            Assert.Equal("Custom Name", JsonSchema.ToTitle("custom__name"));
+        }
+
+        [Fact]
+        public void TestClassWithCustomJsonFieldName() {
+            var model = new ClassWithCustomJsonFieldName();
+            var schemaGenerator = new ModelToJsonSchema();
+            var schema = schemaGenerator.ToJsonSchema(nameof(ClassWithCustomJsonFieldName), model);
+
+            Assert.True(schema.properties.ContainsKey("custom_Name"));
+            Assert.True(schema.properties.ContainsKey("fieldWithoutAttribute"));
+
+            Assert.Equal("Custom Name", schema.properties["custom_Name"].title);
+            Assert.Equal("Field Without Attribute", schema.properties["fieldWithoutAttribute"].title);
+        }
+
+        private class ClassWithCustomJsonFieldName {
+
+            [JsonProperty("custom_Name")]
+            public string Name { get; set; }
+
+            public string fieldWithoutAttribute { get; set; }
+
+        }
+
+
         /// <summary>
         /// The following test uses the validator of System.ComponentModel to validate the model / object instance
         /// fields have values that are within the defined limits (enforced via the annotations on the model fields)
@@ -201,7 +220,7 @@ namespace com.csutil.tests.model.jsonschema {
             var isValid = Validator.TryValidateObject(user, new ValidationContext(user), validationResults, true);
             Assert.True(isValid, "User model should be valid, but was not: " + JsonWriter.GetWriter().Write(validationResults));
             Assert.Empty(validationResults); // No validation errors should be present
-            
+
             // Now test with an invalid user model:
             {
                 var invalidUser1 = new MyUserModel() {
@@ -303,15 +322,6 @@ namespace com.csutil.tests.model.jsonschema {
 
             [Enum("Level of experience 5", "Beginner", "Avg", "Expert")]
             public int experience5;
-
-        }
-
-        private class JsonFieldNameTestModel {
-
-            [JsonProperty("custom_name")]
-            public string Name { get; set; }
-
-            public string fieldWithoutAttribute { get; set; }
 
         }
 

--- a/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
+++ b/CsCore/xUnitTests/src/Plugins/CsCoreXUnitTests/com/csutil/tests/model/jsonschema/JsonSchemaTests.cs
@@ -173,6 +173,11 @@ namespace com.csutil.tests.model.jsonschema {
             Assert.Equal("Custom Name", JsonSchema.ToTitle("_Custom_name"));
             Assert.Equal("Custom Name", JsonSchema.ToTitle("_custom_name"));
             Assert.Equal("Custom Name", JsonSchema.ToTitle("custom__name"));
+            Assert.Equal("Custom Name 2", JsonSchema.ToTitle("customName2"));
+            Assert.Equal("Custom Name 22", JsonSchema.ToTitle("customName_22"));
+            Assert.Equal("2 Custom Name", JsonSchema.ToTitle("2CustomName"));
+            Assert.Equal("Custom 2 Name", JsonSchema.ToTitle("Custom2Name"));
+            Assert.Equal("Custom 22 Name", JsonSchema.ToTitle("Custom_22_Name"));
         }
 
         [Fact]


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, focusing primarily on OpenAI API integration, Unity UI enhancements, and CI workflow automation. The most significant changes include stricter validation and configuration for OpenAI chat requests, the addition of a custom blur shader for Unity's Universal Render Pipeline (URP), and a new GitHub Actions workflow for running and reporting .NET tests.

**OpenAI API improvements:**

* Replaced the `max_tokens` property with `max_completion_tokens` in `OpenAi.cs` to align with the latest OpenAI API specification and clarified its usage in both request classes. The constructors were updated to remove manual token calculation logic. [[1]](diffhunk://#diff-9c8acfb802e35e44e6d15a4d94d1ae7d5642b2d6860fcbaea23d3d31a36e50c8L213-R220) [[2]](diffhunk://#diff-9c8acfb802e35e44e6d15a4d94d1ae7d5642b2d6860fcbaea23d3d31a36e50c8L362-R383) [[3]](diffhunk://#diff-9c8acfb802e35e44e6d15a4d94d1ae7d5642b2d6860fcbaea23d3d31a36e50c8L233-L239)
* Added stricter validation for JSON schema response formats: now throws exceptions if `additionalProperties` is set to true, if the schema name does not match the required pattern, or if the schema type is not `"object"`. This ensures compatibility with OpenAI's strict JSON schema requirements. [[1]](diffhunk://#diff-9c8acfb802e35e44e6d15a4d94d1ae7d5642b2d6860fcbaea23d3d31a36e50c8L260-R267) [[2]](diffhunk://#diff-9c8acfb802e35e44e6d15a4d94d1ae7d5642b2d6860fcbaea23d3d31a36e50c8R289-R294)
* Introduced a convenience method to set the response format to a JSON schema based on a generic type, simplifying API usage.

**Unity UI and rendering enhancements:**

* Added a new custom blur shader (`BlurUrp.shader`) and associated material (`BlurUrp.mat`) for the Universal Render Pipeline, enabling advanced blur effects for UI elements. Included all necessary Unity asset metadata files for integration. [[1]](diffhunk://#diff-5ea30c8965d1823e67196c7652f5088c826a1a8da34dea02dd6faee8ac7e4f3cR1-R117) [[2]](diffhunk://#diff-682f550ae2adf08e62e1d1e2460bae035afaeb3090383cfa165e12fd2beb4a6eR1-R149) [[3]](diffhunk://#diff-6a3630faad9c6183caa64d5476a90c44f4fdd864947b30c32ccd1258b370f69fR1-R8) [[4]](diffhunk://#diff-b7737d9f0a5f84aca9d8d36108a653a24ab2699053bf99f74d7427e86c549338R1-R9) [[5]](diffhunk://#diff-2bebf5f18e51c791a7c6a381208f83a68da2bf418f716d9ea20408e89d6ae903R1-R8) [[6]](diffhunk://#diff-779d2a91572bb11886e6cf231a9453a194e5582bc3fbcebb16f66334e5417901R1-R7)

**Continuous Integration and Testing:**

* Added a new GitHub Actions workflow (`dotnet-tests.yml`) for building, running, and reporting .NET tests, with safe caching and exclusion of integration tests for faster feedback. Automated test result reporting is included for non-forked pull requests.

**Miscellaneous improvements:**

* Improved enum validation by excluding system enums from power-of-two checks, reducing unnecessary warnings for enums outside developer control.
* Updated `JsonModelExtensions.cs` to use the correct schema source (`anyOf`) when creating new list entries and child views, improving compatibility with complex JSON schemas. [[1]](diffhunk://#diff-4033cc62c3a4d62a3244e004d5b703af04e6fcfd70add752db4ab68349a14604L213-R213) [[2]](diffhunk://#diff-4033cc62c3a4d62a3244e004d5b703af04e6fcfd70add752db4ab68349a14604L259-R259)
* Added missing `using` statements in `OpenAi.cs` for regex and model support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cs-util-com/cscore/135)
<!-- Reviewable:end -->
